### PR TITLE
[npm] add prepublish task

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/unfort.js",
   "scripts": {
     "build": "./scripts/build.js",
+    "prepublish": "npm run build -- --once",
     "test": "mocha --require source-map-support/register --reporter spec 'lib/**/tests/*.js'",
     "_test": "mocha --reporter spec 'lib/**/tests/*.js'",
     "lint": "eslint runtimes/*.js scripts/**.js src/**.js",


### PR DESCRIPTION
Adding a prepublish task allows linking unfort from another module without needing to explicitly run `npm run build` and ensures that the build process runs before publishing to npm.
